### PR TITLE
ci(Dockerfile): pin `bindgen-cli` version to 0.63.0

### DIFF
--- a/rust-sgx-workspace/Dockerfile
+++ b/rust-sgx-workspace/Dockerfile
@@ -134,7 +134,7 @@ USER user
 RUN --mount=type=cache,sharing=locked,uid=1000,gid=1000,target=/home/user/.cargo/registry \
     --mount=type=cache,sharing=locked,uid=1000,gid=1000,target=/home/user/.cargo/git \
     . ~/.cargo/env && \
-    cargo install bindgen
+    cargo install --version 0.63.0 bindgen-cli
 
 # Cargo make
 USER root


### PR DESCRIPTION
```
`bindgen` recently split out their cli-tool and the library into two parts.
This is causing our web-server tests to fail.
```

https://github.com/ntls-io/nautilus-wallet/pull/395/files
https://github.com/ntls-io/nautilus-wallet/pull/517