### PR TITLE
refactor: change 'pin' to 'password'

### DIFF
--- a/rust-sgx-workspace/crates/sgx-vault-impl/src/schema/actions.rs
+++ b/rust-sgx-workspace/crates/sgx-vault-impl/src/schema/actions.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::schema::entities::VaultDisplay;
-use crate::schema::types::{Bytes, VaultId, VaultPin};
+use crate::schema::types::{Bytes, VaultId, VaultPassword};
 use crate::vault_operations::store::UnlockVaultError;
 
 #[derive(Clone, Eq, PartialEq, Debug)] // core
@@ -18,7 +18,7 @@ use crate::vault_operations::store::UnlockVaultError;
 #[derive(Zeroize, ZeroizeOnDrop)] // zeroize
 pub struct CreateVault {
     pub owner_name: String,
-    pub auth_pin: VaultPin,
+    pub auth_password: VaultPassword,
     pub phone_number: Option<String>,
 }
 
@@ -34,7 +34,7 @@ pub enum CreateVaultResult {
 #[derive(Zeroize, ZeroizeOnDrop)] // zeroize
 pub struct OpenVault {
     pub vault_id: VaultId,
-    pub auth_pin: VaultPin,
+    pub auth_password: VaultPassword,
 }
 
 #[derive(Clone, Eq, PartialEq, Debug)] // core
@@ -50,7 +50,7 @@ impl From<UnlockVaultError> for OpenVaultResult {
         use UnlockVaultError::*;
         match err {
             InvalidVaultId => Self::InvalidAuth,
-            InvalidAuthPin => Self::InvalidAuth,
+            InvalidAuthPassword => Self::InvalidAuth,
             IoError(err) => Self::Failed(err.to_string()),
         }
     }
@@ -61,7 +61,7 @@ impl From<UnlockVaultError> for OpenVaultResult {
 #[derive(Zeroize, ZeroizeOnDrop)] // zeroize
 pub struct SignTransaction {
     pub vault_id: VaultId,
-    pub auth_pin: VaultPin,
+    pub auth_password: VaultPassword,
 
     #[zeroize(skip)]
     pub transaction_to_sign: TransactionToSign,
@@ -72,7 +72,7 @@ impl From<UnlockVaultError> for SignTransactionResult {
         use UnlockVaultError::*;
         match err {
             InvalidVaultId => Self::InvalidAuth,
-            InvalidAuthPin => Self::InvalidAuth,
+            InvalidAuthPassword => Self::InvalidAuth,
             IoError(err) => Self::Failed(err.to_string()),
         }
     }

--- a/rust-sgx-workspace/crates/sgx-vault-impl/src/schema/entities.rs
+++ b/rust-sgx-workspace/crates/sgx-vault-impl/src/schema/entities.rs
@@ -11,7 +11,7 @@ use crate::schema::types::{
     AlgorandAddressBase32,
     AlgorandAddressBytes,
     VaultId,
-    VaultPin,
+    VaultPassword,
 };
 
 /// A Nautilus vault's basic displayable details.
@@ -48,7 +48,7 @@ impl From<VaultStorable> for VaultDisplay {
 #[derive(Zeroize, ZeroizeOnDrop)] // zeroize
 pub struct VaultStorable {
     pub vault_id: VaultId,
-    pub auth_pin: VaultPin,
+    pub auth_password: VaultPassword,
 
     pub owner_name: String,
     pub phone_number: Option<String>,

--- a/rust-sgx-workspace/crates/sgx-vault-impl/src/schema/types.rs
+++ b/rust-sgx-workspace/crates/sgx-vault-impl/src/schema/types.rs
@@ -8,8 +8,8 @@ pub type Bytes = Box<[u8]>;
 /// Nautilus Vault ID.
 pub type VaultId = String;
 
-/// A vault owner's authenticating PIN.
-pub type VaultPin = String;
+/// A vault owner's authenticating password.
+pub type VaultPassword = String;
 
 /// Algorand account seed, as bytes.
 pub type AlgorandAccountSeedBytes = [u8; 32];

--- a/rust-sgx-workspace/crates/sgx-vault-impl/src/vault_operations/create_vault.rs
+++ b/rust-sgx-workspace/crates/sgx-vault-impl/src/vault_operations/create_vault.rs
@@ -14,7 +14,7 @@ pub fn create_vault(request: &CreateVault) -> Result {
     let storable = VaultStorable {
         vault_id: new_algorand_account.address_base32(),
         owner_name: request.owner_name.clone(),
-        auth_pin: request.auth_pin.clone(),
+        auth_password: request.auth_password.clone(),
         phone_number: request.phone_number.clone(),
 
         algorand_account: new_algorand_account,

--- a/rust-sgx-workspace/crates/sgx-vault-impl/src/vault_operations/open_vault.rs
+++ b/rust-sgx-workspace/crates/sgx-vault-impl/src/vault_operations/open_vault.rs
@@ -3,7 +3,7 @@ use crate::schema::entities::VaultDisplay;
 use crate::vault_operations::store::unlock_vault;
 
 pub fn open_vault(request: &OpenVault) -> OpenVaultResult {
-    let stored = match unlock_vault(&request.vault_id, &request.auth_pin) {
+    let stored = match unlock_vault(&request.vault_id, &request.auth_password) {
         Ok(stored) => stored,
         Err(err) => return err.into(),
     };

--- a/rust-sgx-workspace/crates/sgx-vault-impl/src/vault_operations/sign_transaction.rs
+++ b/rust-sgx-workspace/crates/sgx-vault-impl/src/vault_operations/sign_transaction.rs
@@ -12,7 +12,7 @@ use crate::vault_operations::sign_transaction_algorand::sign_algorand;
 use crate::vault_operations::store::unlock_vault;
 
 pub fn sign_transaction(request: &SignTransaction) -> SignTransactionResult {
-    let stored = match unlock_vault(&request.vault_id, &request.auth_pin) {
+    let stored = match unlock_vault(&request.vault_id, &request.auth_password) {
         Ok(stored) => stored,
         Err(err) => return err.into(),
     };

--- a/rust-sgx-workspace/crates/sgx-vault-impl/src/vault_operations/store.rs
+++ b/rust-sgx-workspace/crates/sgx-vault-impl/src/vault_operations/store.rs
@@ -50,12 +50,12 @@ pub fn key_from_id(vault_id: &str) -> Result<Box<Key>, io::Error> {
 }
 
 /// Load and authenticate access to a vault.
-pub fn unlock_vault(vault_id: &str, auth_pin: &str) -> Result<VaultStorable, UnlockVaultError> {
+pub fn unlock_vault(vault_id: &str, auth_password: &str) -> Result<VaultStorable, UnlockVaultError> {
     let stored: VaultStorable = load_vault(vault_id)?.ok_or(UnlockVaultError::InvalidVaultId)?;
 
-    match ConsttimeMemEq::consttime_memeq(stored.auth_pin.as_bytes(), auth_pin.as_bytes()) {
+    match ConsttimeMemEq::consttime_memeq(stored.auth_password.as_bytes(), auth_password.as_bytes()) {
         true => Ok(stored),
-        false => Err(UnlockVaultError::InvalidAuthPin),
+        false => Err(UnlockVaultError::InvalidAuthPassword),
     }
 }
 
@@ -72,7 +72,7 @@ pub enum UnlockVaultError {
     InvalidVaultId,
 
     #[error("invalid authentication PIN provided")]
-    InvalidAuthPin,
+    InvalidAuthPassword,
 
     #[error("I/O error while opening vault")]
     IoError(#[from] io::Error),

--- a/rust-sgx-workspace/projects/sgx-vault-test/enclave/src/helpers/vault_store.rs
+++ b/rust-sgx-workspace/projects/sgx-vault-test/enclave/src/helpers/vault_store.rs
@@ -10,7 +10,7 @@ pub fn create_test_vault() -> VaultDisplay {
 
     let request = &actions::CreateVault {
         owner_name: "New Owner".to_string(),
-        auth_pin: "123456".to_string(),
+        auth_password: "123456".to_string(),
         phone_number: None,
     };
     match create_vault(request) {

--- a/rust-sgx-workspace/projects/sgx-vault-test/enclave/src/vault_operations/test_create_vault.rs
+++ b/rust-sgx-workspace/projects/sgx-vault-test/enclave/src/vault_operations/test_create_vault.rs
@@ -8,7 +8,7 @@ use sgx_vault_impl::vault_operations::store::load_vault;
 pub(crate) fn create_vault_works() {
     let request = &actions::CreateVault {
         owner_name: "New Owner".to_string(),
-        auth_pin: "123456".to_string(),
+        auth_password: "123456".to_string(),
         phone_number: None,
     };
     let display = &match create_vault(request) {

--- a/rust-sgx-workspace/projects/sgx-vault-test/enclave/src/vault_operations/test_dispatch.rs
+++ b/rust-sgx-workspace/projects/sgx-vault-test/enclave/src/vault_operations/test_dispatch.rs
@@ -12,7 +12,7 @@ pub(crate) fn vault_operation_sealing_works() {
     // Seal
     let vault_request = &VaultRequest::OpenVault(OpenVault {
         vault_id: "123456".to_string(),
-        auth_pin: "1234".to_string(),
+        auth_password: "1234".to_string(),
     });
     let sealed_request_bytes =
         &seal_msgpack(vault_request, &enclave_crypto.get_pubkey(), client_crypto).unwrap();

--- a/rust-sgx-workspace/projects/sgx-vault-test/enclave/src/vault_operations/test_open_vault.rs
+++ b/rust-sgx-workspace/projects/sgx-vault-test/enclave/src/vault_operations/test_open_vault.rs
@@ -13,7 +13,7 @@ pub(crate) fn open_vault_works() {
 
     let request = &actions::OpenVault {
         vault_id: existing.vault_id.clone(),
-        auth_pin: "123456".to_string(),
+        auth_password: "123456".to_string(),
     };
     let display = &match open_vault(request) {
         Result::Opened(opened) => opened,
@@ -26,7 +26,7 @@ pub(crate) fn open_vault_works() {
 pub(crate) fn open_vault_malformed_vault_id() {
     let request = &actions::OpenVault {
         vault_id: "malformed".to_string(),
-        auth_pin: "123456".to_string(),
+        auth_password: "123456".to_string(),
     };
 
     match open_vault(request) {
@@ -40,7 +40,7 @@ pub(crate) fn open_vault_bad_pin() {
 
     let request = &actions::OpenVault {
         vault_id: existing.vault_id.clone(),
-        auth_pin: "000000".to_string(),
+        auth_password: "000000".to_string(),
     };
 
     match open_vault(request) {

--- a/rust-sgx-workspace/projects/sgx-vault-test/enclave/src/vault_operations/test_sign_transaction.rs
+++ b/rust-sgx-workspace/projects/sgx-vault-test/enclave/src/vault_operations/test_sign_transaction.rs
@@ -24,7 +24,7 @@ pub(crate) fn sign_transaction_works() {
 
     let request = &actions::SignTransaction {
         vault_id: existing.vault_id.clone(),
-        auth_pin: "123456".to_string(),
+        auth_password: "123456".to_string(),
         transaction_to_sign,
     };
     let signed = sign_transaction(request).unwrap_signed();
@@ -49,7 +49,7 @@ pub(crate) fn sign_transaction_without_tag() {
 
     let request = &actions::SignTransaction {
         vault_id: existing.vault_id.clone(),
-        auth_pin: "123456".to_string(),
+        auth_password: "123456".to_string(),
         transaction_to_sign,
     };
     match sign_transaction(request) {
@@ -75,7 +75,7 @@ pub(crate) fn sign_transaction_empty() {
 
     let request = &actions::SignTransaction {
         vault_id: existing.vault_id.clone(),
-        auth_pin: "123456".to_string(),
+        auth_password: "123456".to_string(),
         transaction_to_sign,
     };
     match sign_transaction(request) {
@@ -99,7 +99,7 @@ pub(crate) fn sign_transaction_malformed_transaction() {
 
     let request = &actions::SignTransaction {
         vault_id: existing.vault_id.clone(),
-        auth_pin: "123456".to_string(),
+        auth_password: "123456".to_string(),
         transaction_to_sign,
     };
     match sign_transaction(request) {


### PR DESCRIPTION
Refactor PR to rename "pin" to "passoword" for NTC.