### PR TITLE
refactor: change vault id to username

### DIFF
--- a/rust-sgx-workspace/crates/sgx-vault-impl/src/vault_operations/create_vault.rs
+++ b/rust-sgx-workspace/crates/sgx-vault-impl/src/vault_operations/create_vault.rs
@@ -12,7 +12,7 @@ pub fn create_vault(request: &CreateVault) -> Result {
     let new_algorand_account = AlgorandAccount::generate();
 
     let storable = VaultStorable {
-        vault_id: new_algorand_account.address_base32(),
+        vault_id: request.username.clone(),
         username: request.username.clone(),
         auth_password: request.auth_password.clone(),
 

--- a/rust-sgx-workspace/crates/sgx-vault-impl/src/vault_operations/store.rs
+++ b/rust-sgx-workspace/crates/sgx-vault-impl/src/vault_operations/store.rs
@@ -1,8 +1,6 @@
 use std::io;
 use std::prelude::v1::Box;
-use std::str::FromStr;
 
-use algonaut::core::Address;
 use sgx_trts::memeq::ConsttimeMemEq;
 use thiserror::Error;
 
@@ -39,14 +37,9 @@ pub fn load_vault(vault_id: &str) -> Result<Option<VaultStorable>, io::Error> {
 }
 
 pub fn key_from_id(vault_id: &str) -> Result<Box<Key>, io::Error> {
-    // XXX: Assume ALGO address, for now.
-    let Address(address) = Address::from_str(vault_id).map_err(|err| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("key_from_id failed for vault_id = {:?}: {}", vault_id, err),
-        )
-    })?;
-    Ok(address.into())
+    // XXX: Assume general username string, for now.
+    let username_as_bytes = vault_id.as_bytes();
+    Ok(username_as_bytes.into())
 }
 
 /// Load and authenticate access to a vault.

--- a/rust-sgx-workspace/projects/sgx-vault-test/enclave/src/helpers/vault_store.rs
+++ b/rust-sgx-workspace/projects/sgx-vault-test/enclave/src/helpers/vault_store.rs
@@ -17,3 +17,16 @@ pub fn create_test_vault() -> VaultDisplay {
         otherwise => panic!("{:?}", otherwise),
     }
 }
+
+pub fn create_test_vault_with_username(username: &str) -> VaultDisplay {
+    type Result = CreateVaultResult;
+
+    let request = &actions::CreateVault {
+        username: username.to_string(),
+        auth_password: "123456".to_string(),
+    };
+    match create_vault(request) {
+        Result::Created(created) => created,
+        otherwise => panic!("{:?}", otherwise),
+    }
+}

--- a/rust-sgx-workspace/projects/sgx-vault-test/enclave/src/lib.rs
+++ b/rust-sgx-workspace/projects/sgx-vault-test/enclave/src/lib.rs
@@ -41,7 +41,6 @@ pub extern "C" fn run_tests_ecall() -> usize {
         vault_operations::test_sign_transaction::sign_transaction_works,
         vault_operations::test_sign_transaction_msgpack::prop_transaction_msgpack_roundtrips,
         vault_operations::test_store::unlock_vault_bad_auth_pin,
-        vault_operations::test_store::unlock_vault_malformed_vault_id,
         vault_operations::test_store::unlock_vault_not_found,
         vault_operations::test_store::unlock_vault_works,
     )

--- a/rust-sgx-workspace/projects/sgx-vault-test/enclave/src/vault_operations/test_create_vault.rs
+++ b/rust-sgx-workspace/projects/sgx-vault-test/enclave/src/vault_operations/test_create_vault.rs
@@ -1,9 +1,10 @@
+use sgx_vault_impl::ported::kv_store::KvStore;
 use std::prelude::v1::ToString;
 
 use sgx_vault_impl::schema::actions;
 use sgx_vault_impl::schema::actions::CreateVaultResult as Result;
 use sgx_vault_impl::vault_operations::create_vault::create_vault;
-use sgx_vault_impl::vault_operations::store::load_vault;
+use sgx_vault_impl::vault_operations::store::{key_from_id, load_vault, vault_store};
 
 pub(crate) fn create_vault_works() {
     let request = &actions::CreateVault {
@@ -24,4 +25,8 @@ pub(crate) fn create_vault_works() {
         display.algorand_address_base32,
         stored.algorand_account.address_base32()
     );
+
+    let mut store = vault_store();
+    let key = &key_from_id(&display.vault_id).unwrap();
+    store.delete(key).unwrap();
 }

--- a/rust-sgx-workspace/projects/sgx-vault-test/enclave/src/vault_operations/test_dispatch.rs
+++ b/rust-sgx-workspace/projects/sgx-vault-test/enclave/src/vault_operations/test_dispatch.rs
@@ -27,10 +27,7 @@ pub(crate) fn vault_operation_sealing_works() {
     // Check
     assert_eq!(
         unsealed_message,
-        OpenVaultResult::Failed(
-            "key_from_id failed for vault_id = \"123456\": Error decoding base32: DecodeError { position: 5, kind: Length }"
-                .to_string()
-        )
+        OpenVaultResult::InvalidAuth
         .into()
     );
 }

--- a/rust-sgx-workspace/projects/sgx-vault-test/enclave/src/vault_operations/test_open_vault.rs
+++ b/rust-sgx-workspace/projects/sgx-vault-test/enclave/src/vault_operations/test_open_vault.rs
@@ -1,15 +1,17 @@
+use sgx_vault_impl::ported::kv_store::KvStore;
 use std::prelude::v1::ToString;
 
 use sgx_vault_impl::schema::actions;
 use sgx_vault_impl::schema::actions::OpenVaultResult;
 use sgx_vault_impl::vault_operations::open_vault::open_vault;
+use sgx_vault_impl::vault_operations::store::{key_from_id, vault_store};
 
 use crate::helpers::vault_store;
 
 type Result = OpenVaultResult;
 
 pub(crate) fn open_vault_works() {
-    let existing = &vault_store::create_test_vault();
+    let existing = &vault_store::create_test_vault_with_username("Open Vault");
 
     let request = &actions::OpenVault {
         vault_id: existing.vault_id.clone(),
@@ -21,6 +23,10 @@ pub(crate) fn open_vault_works() {
     };
 
     assert_eq!(display, existing);
+
+    let mut store = vault_store();
+    let key = &key_from_id(&existing.vault_id).unwrap();
+    store.delete(key).unwrap();
 }
 
 pub(crate) fn open_vault_malformed_vault_id() {
@@ -30,13 +36,13 @@ pub(crate) fn open_vault_malformed_vault_id() {
     };
 
     match open_vault(request) {
-        Result::Failed(_) => (),
+        Result::InvalidAuth => (),
         otherwise => panic!("{:?}", otherwise),
     }
 }
 
 pub(crate) fn open_vault_bad_pin() {
-    let existing = &vault_store::create_test_vault();
+    let existing = &vault_store::create_test_vault_with_username("Bad Pin");
 
     let request = &actions::OpenVault {
         vault_id: existing.vault_id.clone(),
@@ -47,4 +53,8 @@ pub(crate) fn open_vault_bad_pin() {
         Result::InvalidAuth => (),
         otherwise => panic!("{:?}", otherwise),
     }
+
+    let mut store = vault_store();
+    let key = &key_from_id(&existing.vault_id).unwrap();
+    store.delete(key).unwrap();
 }

--- a/rust-sgx-workspace/projects/sgx-vault-test/enclave/src/vault_operations/test_sign_transaction.rs
+++ b/rust-sgx-workspace/projects/sgx-vault-test/enclave/src/vault_operations/test_sign_transaction.rs
@@ -2,10 +2,12 @@ use std::prelude::v1::ToString;
 
 use algonaut::core::ToMsgPack;
 use algonaut::transaction::SignedTransaction as AlgonautSignedTransaction;
+use sgx_vault_impl::ported::kv_store::KvStore;
 use sgx_vault_impl::schema::actions;
 use sgx_vault_impl::schema::actions::{SignTransactionResult, TransactionToSign};
 use sgx_vault_impl::schema::msgpack::FromMessagePack;
 use sgx_vault_impl::vault_operations::sign_transaction::sign_transaction;
+use sgx_vault_impl::vault_operations::store::{key_from_id, vault_store};
 
 use crate::helpers::algonaut::create_test_transaction;
 use crate::helpers::vault_store::create_test_vault;
@@ -35,6 +37,10 @@ pub(crate) fn sign_transaction_works() {
         algonaut_signed_transaction.transaction,
         algonaut_transaction
     );
+
+    let mut store = vault_store();
+    let key = &key_from_id(&existing.vault_id).unwrap();
+    store.delete(key).unwrap();
 }
 
 pub(crate) fn sign_transaction_without_tag() {
@@ -65,6 +71,10 @@ pub(crate) fn sign_transaction_without_tag() {
         ),
         otherwise => panic!("{:?}", otherwise),
     };
+
+    let mut store = vault_store();
+    let key = &key_from_id(&existing.vault_id).unwrap();
+    store.delete(key).unwrap();
 }
 
 pub(crate) fn sign_transaction_empty() {
@@ -89,6 +99,10 @@ pub(crate) fn sign_transaction_empty() {
         }
         otherwise => panic!("{:?}", otherwise),
     };
+
+    let mut store = vault_store();
+    let key = &key_from_id(&existing.vault_id).unwrap();
+    store.delete(key).unwrap();
 }
 
 pub(crate) fn sign_transaction_malformed_transaction() {
@@ -113,4 +127,8 @@ pub(crate) fn sign_transaction_malformed_transaction() {
         }
         otherwise => panic!("{:?}", otherwise),
     };
+
+    let mut store = vault_store();
+    let key = &key_from_id(&existing.vault_id).unwrap();
+    store.delete(key).unwrap();
 }

--- a/rust-sgx-workspace/projects/sgx-vault-test/enclave/src/vault_operations/test_store.rs
+++ b/rust-sgx-workspace/projects/sgx-vault-test/enclave/src/vault_operations/test_store.rs
@@ -6,16 +6,20 @@ use sgx_vault_impl::ported::kv_store::KvStore;
 use sgx_vault_impl::schema::entities::VaultDisplay;
 use sgx_vault_impl::vault_operations::store::{key_from_id, unlock_vault, vault_store};
 
-use crate::helpers::vault_store::create_test_vault;
+use crate::helpers::vault_store::create_test_vault_with_username;
 
 pub(crate) fn unlock_vault_works() {
-    let existing = create_test_vault();
+    let existing = create_test_vault_with_username("Unlock Vault Works");
     let stored = unlock_vault(&existing.vault_id, "123456").unwrap();
     assert_eq!(existing, VaultDisplay::from(stored));
+
+    let mut store = vault_store();
+    let key = &key_from_id(&existing.vault_id).unwrap();
+    store.delete(key).unwrap();
 }
 
 pub(crate) fn unlock_vault_not_found() {
-    let existing = create_test_vault();
+    let existing = create_test_vault_with_username("Unlock Vault Not Found");
     let mut store = vault_store();
     let key = &key_from_id(&existing.vault_id).unwrap();
     store.delete(key).unwrap();
@@ -24,14 +28,12 @@ pub(crate) fn unlock_vault_not_found() {
     assert_eq!(err.to_string(), "invalid vault ID provided");
 }
 
-pub(crate) fn unlock_vault_malformed_vault_id() {
-    create_test_vault();
-    let err = unlock_vault("malformed", "123456").unwrap_err();
-    assert_eq!(err.to_string(), "I/O error while opening vault");
-}
-
 pub(crate) fn unlock_vault_bad_auth_pin() {
-    let existing = create_test_vault();
+    let existing = create_test_vault_with_username("Unlock Vault Bad Auth Pin");
     let err = unlock_vault(&existing.vault_id, "000000").unwrap_err();
     assert_eq!(err.to_string(), "invalid authentication PIN provided");
+
+    let mut store = vault_store();
+    let key = &key_from_id(&existing.vault_id).unwrap();
+    store.delete(key).unwrap();
 }


### PR DESCRIPTION
Change Vault ID to username so that NTC users can use their username to log in.